### PR TITLE
Adapt to joint_trajectory_controller changes

### DIFF
--- a/doc/wiki/KSS_RSI.md
+++ b/doc/wiki/KSS_RSI.md
@@ -130,7 +130,7 @@ Both launch files support the following arguments:
 
 
 The `startup_with_rviz.launch.py` additionally contains one argument:
-- `rviz_config`: the location of the `rviz` configuration file (defaults to `kuka_resources/config/"view_6_axis_urdf.rviz`)
+- `rviz_config`: the location of the `rviz` configuration file (defaults to `kuka_resources/config/view_6_axis_urdf.rviz`)
 
 #### Stopping external control
 

--- a/doc/wiki/Sunrise_FRI.md
+++ b/doc/wiki/Sunrise_FRI.md
@@ -70,7 +70,7 @@ Both launch files support the following argument:
 
 
 The `startup_with_rviz.launch.py` additionally contains one argument:
-- `rviz_config`: the location of the `rviz` configuration file (defaults to `kuka_resources/config/"view_6_axis_urdf.rviz`)
+- `rviz_config`: the location of the `rviz` configuration file (defaults to `kuka_resources/config/view_6_axis_urdf.rviz`)
 
 
 #### Stopping external control

--- a/doc/wiki/iiQKA_EAC.md
+++ b/doc/wiki/iiQKA_EAC.md
@@ -84,7 +84,7 @@ Both launch files support the following arguments:
 
 
 The `startup_with_rviz.launch.py` additionally contains one argument:
-- `rviz_config`: the location of the `rviz` configuration file (defaults to `kuka_resources/config/"view_6_axis_urdf.rviz`)
+- `rviz_config`: the location of the `rviz` configuration file (defaults to `kuka_resources/config/view_6_axis_urdf.rviz`)
 
 #### Stopping external control
 

--- a/kuka_iiqka_eac_driver/config/ros2_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/config/ros2_controller_config.yaml
@@ -1,4 +1,4 @@
-/controller_manager:
+controller_manager:
   ros__parameters:
     update_rate: 250  # Hz
 

--- a/kuka_iiqka_eac_driver/launch/startup.launch.py
+++ b/kuka_iiqka_eac_driver/launch/startup.launch.py
@@ -106,7 +106,7 @@ def launch_setup(context, *args, **kwargs):
         namespace=ns,
         package="kuka_drivers_core",
         executable="control_node",
-        parameters=[robot_description, controller_config],
+        parameters=[robot_description, controller_config, jtc_config],
     )
     robot_manager_node = LifecycleNode(
         name=["robot_manager"],
@@ -146,7 +146,7 @@ def launch_setup(context, *args, **kwargs):
 
     controller_names_and_config = [
         ("joint_state_broadcaster", []),
-        ("joint_trajectory_controller", jtc_config.perform(context)),
+        ("joint_trajectory_controller", []),
         ("joint_group_impedance_controller", jic_config.perform(context)),
         ("effort_controller", ec_config.perform(context)),
         ("control_mode_handler", []),

--- a/kuka_iiqka_eac_driver/launch/startup.launch.py
+++ b/kuka_iiqka_eac_driver/launch/startup.launch.py
@@ -150,9 +150,7 @@ def launch_setup(context, *args, **kwargs):
         "control_mode_handler",
     ]
 
-    controller_spawners = [
-        controller_spawner(name) for name in controller_names
-    ]
+    controller_spawners = [controller_spawner(name) for name in controller_names]
 
     nodes_to_start = [
         control_node,

--- a/kuka_iiqka_eac_driver/launch/startup.launch.py
+++ b/kuka_iiqka_eac_driver/launch/startup.launch.py
@@ -106,7 +106,7 @@ def launch_setup(context, *args, **kwargs):
         namespace=ns,
         package="kuka_drivers_core",
         executable="control_node",
-        parameters=[robot_description, controller_config, jtc_config],
+        parameters=[robot_description, controller_config, jtc_config, jic_config, ec_config],
     )
     robot_manager_node = LifecycleNode(
         name=["robot_manager"],
@@ -147,8 +147,8 @@ def launch_setup(context, *args, **kwargs):
     controller_names_and_config = [
         ("joint_state_broadcaster", []),
         ("joint_trajectory_controller", []),
-        ("joint_group_impedance_controller", jic_config.perform(context)),
-        ("effort_controller", ec_config.perform(context)),
+        ("joint_group_impedance_controller", []),
+        ("effort_controller", []),
         ("control_mode_handler", []),
     ]
 

--- a/kuka_iiqka_eac_driver/launch/startup.launch.py
+++ b/kuka_iiqka_eac_driver/launch/startup.launch.py
@@ -130,13 +130,11 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # Spawn controllers
-    def controller_spawner(controller_with_config, activate=False):
+    def controller_spawner(controller_names, activate=False):
         arg_list = [
-            controller_with_config[0],
+            controller_names,
             "-c",
             controller_manager_node,
-            "-p",
-            controller_with_config[1],
             "-n",
             ns,
         ]
@@ -144,16 +142,16 @@ def launch_setup(context, *args, **kwargs):
             arg_list.append("--inactive")
         return Node(package="controller_manager", executable="spawner", arguments=arg_list)
 
-    controller_names_and_config = [
-        ("joint_state_broadcaster", []),
-        ("joint_trajectory_controller", []),
-        ("joint_group_impedance_controller", []),
-        ("effort_controller", []),
-        ("control_mode_handler", []),
+    controller_names = [
+        "joint_state_broadcaster",
+        "joint_trajectory_controller",
+        "joint_group_impedance_controller",
+        "effort_controller",
+        "control_mode_handler",
     ]
 
     controller_spawners = [
-        controller_spawner(controllers) for controllers in controller_names_and_config
+        controller_spawner(name) for name in controller_names
     ]
 
     nodes_to_start = [

--- a/kuka_kss_rsi_driver/launch/startup.launch.py
+++ b/kuka_kss_rsi_driver/launch/startup.launch.py
@@ -132,9 +132,7 @@ def launch_setup(context, *args, **kwargs):
         "joint_trajectory_controller",
     ]
 
-    controller_spawners = [
-        controller_spawner(name) for name in controller_names
-    ]
+    controller_spawners = [controller_spawner(name) for name in controller_names]
 
     nodes_to_start = [
         control_node,

--- a/kuka_kss_rsi_driver/launch/startup.launch.py
+++ b/kuka_kss_rsi_driver/launch/startup.launch.py
@@ -115,13 +115,11 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # Spawn controllers
-    def controller_spawner(controller_with_config, activate=False):
+    def controller_spawner(controller_names, activate=False):
         arg_list = [
-            controller_with_config[0],
+            controller_names,
             "-c",
             controller_manager_node,
-            "-p",
-            controller_with_config[1],
             "-n",
             ns,
         ]
@@ -129,13 +127,13 @@ def launch_setup(context, *args, **kwargs):
             arg_list.append("--inactive")
         return Node(package="controller_manager", executable="spawner", arguments=arg_list)
 
-    controller_names_and_config = [
-        ("joint_state_broadcaster", []),
-        ("joint_trajectory_controller", []),
+    controller_names = [
+        "joint_state_broadcaster",
+        "joint_trajectory_controller",
     ]
 
     controller_spawners = [
-        controller_spawner(controllers) for controllers in controller_names_and_config
+        controller_spawner(name) for name in controller_names
     ]
 
     nodes_to_start = [

--- a/kuka_kss_rsi_driver/launch/startup.launch.py
+++ b/kuka_kss_rsi_driver/launch/startup.launch.py
@@ -97,7 +97,7 @@ def launch_setup(context, *args, **kwargs):
         namespace=ns,
         package="kuka_drivers_core",
         executable="control_node",
-        parameters=[robot_description, controller_config],
+        parameters=[robot_description, controller_config, jtc_config],
     )
     robot_manager_node = LifecycleNode(
         name=["robot_manager"],
@@ -131,7 +131,7 @@ def launch_setup(context, *args, **kwargs):
 
     controller_names_and_config = [
         ("joint_state_broadcaster", []),
-        ("joint_trajectory_controller", jtc_config.perform(context)),
+        ("joint_trajectory_controller", []),
     ]
 
     controller_spawners = [

--- a/kuka_sunrise_fri_driver/launch/startup.launch.py
+++ b/kuka_sunrise_fri_driver/launch/startup.launch.py
@@ -136,9 +136,7 @@ def launch_setup(context, *args, **kwargs):
         "fri_state_broadcaster",
     ]
 
-    controller_spawners = [
-        controller_spawner(name) for name in controller_names
-    ]
+    controller_spawners = [controller_spawner(name) for name in controller_names]
 
     nodes_to_start = [
         control_node,

--- a/kuka_sunrise_fri_driver/launch/startup.launch.py
+++ b/kuka_sunrise_fri_driver/launch/startup.launch.py
@@ -117,13 +117,11 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # Spawn controllers
-    def controller_spawner(controller_with_config, activate=False):
+    def controller_spawner(controller_names, activate=False):
         arg_list = [
-            controller_with_config[0],
+            controller_names,
             "-c",
             controller_manager_node,
-            "-p",
-            controller_with_config[1],
             "-n",
             ns,
         ]
@@ -131,15 +129,15 @@ def launch_setup(context, *args, **kwargs):
             arg_list.append("--inactive")
         return Node(package="controller_manager", executable="spawner", arguments=arg_list)
 
-    controller_names_and_config = [
-        ("joint_state_broadcaster", []),
-        ("joint_trajectory_controller", []),
-        ("fri_configuration_controller", []),
-        ("fri_state_broadcaster", []),
+    controller_names = [
+        "joint_state_broadcaster",
+        "joint_trajectory_controller",
+        "fri_configuration_controller",
+        "fri_state_broadcaster",
     ]
 
     controller_spawners = [
-        controller_spawner(controllers) for controllers in controller_names_and_config
+        controller_spawner(name) for name in controller_names
     ]
 
     nodes_to_start = [

--- a/kuka_sunrise_fri_driver/launch/startup.launch.py
+++ b/kuka_sunrise_fri_driver/launch/startup.launch.py
@@ -93,7 +93,7 @@ def launch_setup(context, *args, **kwargs):
         namespace=ns,
         package="kuka_drivers_core",
         executable="control_node",
-        parameters=[robot_description, controller_config],
+        parameters=[robot_description, controller_config, jtc_config],
     )
     robot_manager_node = LifecycleNode(
         name=["robot_manager"],
@@ -133,7 +133,7 @@ def launch_setup(context, *args, **kwargs):
 
     controller_names_and_config = [
         ("joint_state_broadcaster", []),
-        ("joint_trajectory_controller", jtc_config.perform(context)),
+        ("joint_trajectory_controller", []),
         ("fri_configuration_controller", []),
         ("fri_state_broadcaster", []),
     ]


### PR DESCRIPTION
The `joint_trajectory_controller` parameter handling was modified in [this PR](https://github.com/ros-controls/ros2_controllers/pull/771), therefore the jtc config file must be loaded by the `controller_manager` node instead of the `spawner`