### PR TITLE
FIX: Using the correct port

### DIFF
--- a/kuka_sunrise_fri_driver/src/hardware_interface.cpp
+++ b/kuka_sunrise_fri_driver/src/hardware_interface.cpp
@@ -150,7 +150,7 @@ CallbackReturn KukaFRIHardwareInterface::on_init(
 CallbackReturn KukaFRIHardwareInterface::on_configure(const rclcpp_lifecycle::State &)
 {
   // Set up UDP connection (UDP replier on client)
-  if (!client_application_.connect(30200, controller_ip_.c_str()))
+  if (!client_application_.connect(client_port_, controller_ip_.c_str()))
   {
     RCLCPP_ERROR(rclcpp::get_logger("KukaFRIHardwareInterface"), "Could not set up UDP connection");
     return CallbackReturn::FAILURE;


### PR DESCRIPTION
With this PR, a solution for the issue #194 is proposed.

It happens because in the Sunrise Java application, the remote port is set [at this line](https://github.com/kroshu/kuka_drivers/blob/bd4ffa520530540f0c68fdbe072d843b6e416bd1/kuka_sunrise_fri_driver/robot_application/src/ros2/serialization/FRIConfigurationParams.java#L58) and, by default, also the port on Controller side is set to the same value (see the screenshot of the official FRI documentation below).

![image](https://github.com/user-attachments/assets/0a87cb1b-4b35-487b-8419-bd5a00db1d67)

The issue could be fixed in two possible ways:

1. The _client_port_ parameter can be used for establishing the FRI communication, instead of the standard port 30200.
2. Setting the port on controller side to 30200 using _setPortOnController()_ function and using two different port for the UDP connection on client side.

The documentation states: 

> **Note**: Only change the port number on the robot controller if the application requires different port numbers on both sides of the FRI channel.

In my interpretation, the port on the controller side should be different from the one on client side **only** if the application requires explicitly two different ports on the two sides.
Given that this one is not the case, and that the fix is extremely easy when we set the _client_port_ on both sides, I implemented the first fix.