### PR TITLE
Fix sunrise activation

### DIFF
--- a/kuka_sunrise_fri_driver/include/kuka_sunrise_fri_driver/hardware_interface.hpp
+++ b/kuka_sunrise_fri_driver/include/kuka_sunrise_fri_driver/hardware_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef KUKA_SUNRISE_FRI_DRIVER__HARDWARE_INTERFACE_HPP_
 #define KUKA_SUNRISE_FRI_DRIVER__HARDWARE_INTERFACE_HPP_
 
+#include <atomic>
 #include <condition_variable>
 #include <memory>
 #include <string>
@@ -157,8 +158,9 @@ private:
 
   RobotState robot_state_;
 
-  std::atomic<bool> fri_started_(false);
-  std::atomic<bool> control_activated_(false);
+  std::atomic<bool> fri_started_{false};
+  std::atomic<bool> control_activated_{false};
+  std::atomic<bool> thread_running_{false};
 
   void activateFrictionCompensation(double * values) const;
   void onError();

--- a/kuka_sunrise_fri_driver/include/kuka_sunrise_fri_driver/hardware_interface.hpp
+++ b/kuka_sunrise_fri_driver/include/kuka_sunrise_fri_driver/hardware_interface.hpp
@@ -157,6 +157,9 @@ private:
 
   RobotState robot_state_;
 
+  std::atomic<bool> fri_started_(false);
+  std::atomic<bool> control_activated_(false);
+
   void activateFrictionCompensation(double * values) const;
   void onError();
 

--- a/kuka_sunrise_fri_driver/src/hardware_interface.cpp
+++ b/kuka_sunrise_fri_driver/src/hardware_interface.cpp
@@ -294,8 +294,10 @@ void KukaFRIHardwareInterface::command()
 hardware_interface::return_type KukaFRIHardwareInterface::read(
   const rclcpp::Time &, const rclcpp::Duration &)
 {
-  // Make sure to only call client app calls if not called from elsewhere 
-  if (!fri_started_ || !control_activated_)
+  // Make sure to only call client app calls if not called from the other thread
+  // This is relevant only for backward compatibility, as new mutex disables 
+  //  on_activate() and read() at the same time
+  if (thread_running_)
   {
     active_read_ = false;
     return hardware_interface::return_type::OK;


### PR DESCRIPTION
A new mutex was added to ros_control that disables calling the hardware interface read, write and on_activate methods at the same time
To adapt to this change, the TCP communication for the activation of fri has been moved to a different thread and UDP cyclic communication (which is necessary for starting FRI) is implemented on the main thread while activating