### PR TITLE
Handle Failed Motion State Reception – Humble Backport

### DIFF
--- a/kuka_rsi_driver/src/hardware_interface_eki_rsi.cpp
+++ b/kuka_rsi_driver/src/hardware_interface_eki_rsi.cpp
@@ -475,6 +475,11 @@ void KukaEkiRsiHardwareInterface::Read(const int64_t request_timeout)
       }
     }
   }
+  else
+  {
+    RCLCPP_ERROR(logger_, "Failed to receive motion state: %s", motion_state_status.message);
+    set_server_event(kuka_drivers_core::HardwareEvent::ERROR);
+  }
 
   std::lock_guard<std::mutex> lk(event_mutex_);
   server_state_ = static_cast<double>(last_event_);


### PR DESCRIPTION
Sorry, I used the wrong branch name, which caused one of the actions to fail.