### PR TITLE
Cleanup package.xml dependencies

### DIFF
--- a/controllers/fri_configuration_controller/package.xml
+++ b/controllers/fri_configuration_controller/package.xml
@@ -7,7 +7,6 @@
 
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
 

--- a/controllers/fri_state_broadcaster/package.xml
+++ b/controllers/fri_state_broadcaster/package.xml
@@ -7,7 +7,6 @@
 
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
 

--- a/controllers/joint_group_impedance_controller/package.xml
+++ b/controllers/joint_group_impedance_controller/package.xml
@@ -7,7 +7,6 @@
 
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
 

--- a/controllers/kuka_control_mode_handler/package.xml
+++ b/controllers/kuka_control_mode_handler/package.xml
@@ -7,7 +7,6 @@
 
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
 

--- a/controllers/kuka_controllers/package.xml
+++ b/controllers/kuka_controllers/package.xml
@@ -5,7 +5,6 @@
   <description>ROS2 controllers for KUKA robots</description>
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
   <license>Apache-2.0</license>

--- a/controllers/kuka_event_broadcaster/package.xml
+++ b/controllers/kuka_event_broadcaster/package.xml
@@ -7,7 +7,6 @@
 
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
 

--- a/controllers/kuka_kss_message_handler/package.xml
+++ b/controllers/kuka_kss_message_handler/package.xml
@@ -13,8 +13,6 @@
 
   <depend>controller_interface</depend>
   <depend>pluginlib</depend>
-  <depend>rclcpp</depend>
-  <depend>rclcpp_lifecycle</depend>
   <depend>std_msgs</depend>
   <depend>kuka_drivers_core</depend>
   <depend>kuka_driver_interfaces</depend>

--- a/kuka_driver_interfaces/package.xml
+++ b/kuka_driver_interfaces/package.xml
@@ -6,7 +6,6 @@
   <description>Message definitions necessary for using KUKA drivers</description>
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
   <license>Apache-2.0</license>

--- a/kuka_drivers/package.xml
+++ b/kuka_drivers/package.xml
@@ -5,7 +5,6 @@
   <description>ROS2 drivers for KUKA robots</description>
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
   <license>Apache-2.0</license>

--- a/kuka_drivers_core/package.xml
+++ b/kuka_drivers_core/package.xml
@@ -6,7 +6,6 @@
   <description>Package containing ROS2 core functions for KUKA robots</description>
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
   <license>Apache-2.0</license>

--- a/kuka_iiqka_eac_driver/package.xml
+++ b/kuka_iiqka_eac_driver/package.xml
@@ -6,7 +6,6 @@
   <description>A ROS2 hardware interface for use with KUKA iiQKA OS</description>
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
   <license>Apache-2.0</license>
@@ -21,7 +20,7 @@
   <depend>controller_manager_msgs</depend>
 
   <exec_depend>kuka_lbr_iisy_support</exec_depend>
-  <exec_depend>ros2_control</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>effort_controllers</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>

--- a/kuka_rsi_driver/package.xml
+++ b/kuka_rsi_driver/package.xml
@@ -6,7 +6,6 @@
   <description>A ROS2 hardware interface for use with KUKA RSI</description>
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
   <license>Apache-2.0</license>
@@ -20,17 +19,14 @@
   <depend>kuka_drivers_core</depend>
   <depend>pluginlib</depend>
   <depend>std_msgs</depend>
-
   <depend>tinyxml_vendor</depend>
 
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
-  <exec_depend>gpio_controllers</exec_depend>
   <exec_depend>kuka_control_mode_handler</exec_depend>
   <exec_depend>kuka_kss_message_handler</exec_depend>
   <exec_depend>kuka_event_broadcaster</exec_depend>
-  <exec_depend>kuka_robot_descriptions</exec_depend>
-  <exec_depend>ros2_control</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
 
   <test_depend>kuka_rsi_simulator</test_depend>
   <test_depend>ros2lifecycle</test_depend>

--- a/kuka_sunrise_fri_driver/package.xml
+++ b/kuka_sunrise_fri_driver/package.xml
@@ -6,7 +6,6 @@
   <description>ROS2 KUKA sunrise interface</description>
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <maintainer email="kovacsge.work@gmail.com">Gergely Kovacs</maintainer>
-  <maintainer email="sanyi.komaromi@gmail.com">Sandor Komaromi</maintainer>
   <maintainer email="pasztor.kristof.kp@gmail.com">Kristof Matyas Pasztor</maintainer>
   <maintainer email="pepo.tamas@gmail.com">Tamas Pepo</maintainer>
   <license>Apache-2.0</license>
@@ -22,7 +21,7 @@
 
   <depend>libnanopb-dev</depend>
 
-  <exec_depend>ros2_control</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>fri_configuration_controller</exec_depend>


### PR DESCRIPTION
colcon also enforces exec_dependencies to be available when building a package, which disables deploying only a few packages to machine with limited resources.
Therefore dependencies that are not strictly mandatory, have been removed in this PR