### PR TITLE
Remove also all '_' from the robot model received from the controller.

### DIFF
--- a/kuka_rsi_driver/src/hardware_interface_eki_rsi.cpp
+++ b/kuka_rsi_driver/src/hardware_interface_eki_rsi.cpp
@@ -173,6 +173,8 @@ std::string ProcessKrcReportedRobotName(const std::string & input)
   std::size_t space_pos = trimmed.find(' ');
   std::string robot_model = trimmed.substr(0, space_pos);
   std::transform(robot_model.begin(), robot_model.end(), robot_model.begin(), ::tolower);
+  // Remove underscores to match URDF processing
+  robot_model.erase(std::remove(robot_model.begin(), robot_model.end(), '_'), robot_model.end());
   return robot_model;
 }
 


### PR DESCRIPTION
This fixes the verification of the robot model. Tested on the "KR 10 R900-2".
Picture of the type shield to make sure that I didn't confuse something.

![4032-3024-max](https://github.com/user-attachments/assets/28c25486-6490-4e49-8fb5-ac981d5c76c3)


## Error
```
[control_node-1] [ERROR] [1771439846.499490172] [KukaEkiRsiHardwareInterface]: The driver is incompatible with the current hardware and software setup: Robotmodel mismatch detected: expected model 'kr10r9002', but found 'kr10r900_2'
[control_node-1] [ERROR] [1771439846.499589502] [resource_manager]: Failed to 'configure' hardware 'kr10_r900_2'
[robot_manager_node_extended-2] [ERROR] [1771439846.499934384] [robot_manager]: Could not configure hardware interface
```

## Solution
It seems to me that the string received from the robot has also `_` in it, but we are not removing it, therefore there is an issue.
So we should also process the string from received from the KRC and remove all `_` from it.

After the proposed change I get output:
```
[control_node-1] [INFO] [1771441063.542412850] [KukaEkiRsiHardwareInterface]: The driver is compatible with the current hardware and software setup
```
