### PR TITLE
Migrate kuka_drivers to ros2_controllers Lyrical

### DIFF
--- a/controllers/fri_configuration_controller/CMakeLists.txt
+++ b/controllers/fri_configuration_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(fri_configuration_controller)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -20,7 +20,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   include
 )
 
-ament_target_dependencies(${PROJECT_NAME} controller_interface kuka_driver_interfaces kuka_drivers_core
+target_link_libraries(${PROJECT_NAME}
+  controller_interface::controller_interface
+  kuka_driver_interfaces::kuka_driver_interfaces
+  kuka_drivers_core::kuka_drivers_core
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/controllers/fri_state_broadcaster/CMakeLists.txt
+++ b/controllers/fri_state_broadcaster/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(fri_state_broadcaster)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -20,7 +20,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   include
 )
 
-ament_target_dependencies(${PROJECT_NAME} controller_interface kuka_driver_interfaces kuka_drivers_core
+target_link_libraries(${PROJECT_NAME}
+  controller_interface::controller_interface
+  kuka_driver_interfaces::kuka_driver_interfaces
+  kuka_drivers_core::kuka_drivers_core
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/controllers/joint_group_impedance_controller/CMakeLists.txt
+++ b/controllers/joint_group_impedance_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(joint_group_impedance_controller)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -25,9 +25,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   include
 )
 
-ament_target_dependencies(${PROJECT_NAME} forward_command_controller kuka_drivers_core
+target_link_libraries(${PROJECT_NAME}
+  forward_command_controller::forward_command_controller
+  kuka_drivers_core::kuka_drivers_core
+  joint_group_impedance_controller_parameters
 )
-target_link_libraries(${PROJECT_NAME} joint_group_impedance_controller_parameters)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/controllers/kuka_control_mode_handler/CMakeLists.txt
+++ b/controllers/kuka_control_mode_handler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(kuka_control_mode_handler)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -19,7 +19,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   include
 )
 
-ament_target_dependencies(${PROJECT_NAME} controller_interface std_msgs kuka_drivers_core
+target_link_libraries(${PROJECT_NAME}
+  controller_interface::controller_interface
+  std_msgs::std_msgs
+  kuka_drivers_core::kuka_drivers_core
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/controllers/kuka_control_mode_handler/CMakeLists.txt
+++ b/controllers/kuka_control_mode_handler/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(controller_interface REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(kuka_drivers_core REQUIRED)
 

--- a/controllers/kuka_event_broadcaster/CMakeLists.txt
+++ b/controllers/kuka_event_broadcaster/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(kuka_event_broadcaster)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -19,7 +19,9 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   include
 )
 
-ament_target_dependencies(${PROJECT_NAME} controller_interface kuka_drivers_core
+target_link_libraries(${PROJECT_NAME}
+  controller_interface::controller_interface
+  kuka_drivers_core::kuka_drivers_core
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/controllers/kuka_kss_message_handler/CMakeLists.txt
+++ b/controllers/kuka_kss_message_handler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(kuka_kss_message_handler)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -22,15 +22,15 @@ target_compile_features(kuka_kss_message_handler PUBLIC c_std_99 cxx_std_17)  # 
 target_include_directories(kuka_kss_message_handler PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-ament_target_dependencies(
+target_link_libraries(
   kuka_kss_message_handler
-  controller_interface
-  pluginlib
-  rclcpp
-  rclcpp_lifecycle
-  std_msgs
-  kuka_drivers_core
-  kuka_driver_interfaces
+  controller_interface::controller_interface
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  std_msgs::std_msgs
+  kuka_drivers_core::kuka_drivers_core
+  kuka_driver_interfaces::kuka_driver_interfaces
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/doc/wiki/1_iiQKA_EAC.md
+++ b/doc/wiki/1_iiQKA_EAC.md
@@ -69,7 +69,7 @@ This starts the 3 core components of every driver (described in the [Non-real-ti
 - `joint_state_broadcaster` (no configuration file, all state interfaces are published)
 - `joint_trajectory_controller` ([configuration file](https://github.com/kroshu/kuka_drivers/tree/master/kuka_iiqka_eac_driver/config/joint_trajectory_controller_config.yaml))
 - `joint_group_impedance_controller` ([configuration file](https://github.com/kroshu/kuka_drivers/tree/master/kuka_iiqka_eac_driver/config/joint_impedance_controller_config.yaml))
-- `effort_controller` (of type `JointGroupPositionController`, [configuration file](https://github.com/kroshu/kuka_drivers/tree/master/kuka_iiqka_eac_driver/config/effort_controller_config.yaml))
+- `effort_controller` (of type `ForwardCommandController`, [configuration file](https://github.com/kroshu/kuka_drivers/tree/master/kuka_iiqka_eac_driver/config/effort_controller_config.yaml))
 - [`kuka_control_mode_handler`](https://github.com/kroshu/kuka_drivers/wiki/5_Controllers#kuka_control_mode_handler) (no configuration file)
 
 After successful startup, the `robot_manager` node has to be activated to start the cyclic communication with the robot controller (before this only a collapsed robot is visible in `rviz`):

--- a/doc/wiki/4_Sunrise_FRI.md
+++ b/doc/wiki/4_Sunrise_FRI.md
@@ -55,7 +55,7 @@ The parameters in the driver configuration file can be also changed during runti
     - [`fri_configuration_controller`](https://github.com/kroshu/kuka_drivers/wiki/5_Controllers#32-fri_configuration_controller) (no configuration file)
     - [`fri_state_broadcaster`](https://github.com/kroshu/kuka_drivers/wiki/5_Controllers#21-fri_state_broadcaster) (no configuration file)
     - `joint_group_impedance_controller` ([configuration file](https://github.com/kroshu/kuka_drivers/tree/master/kuka_sunrise_fri_driver/config/joint_impedance_controller_config.yaml))
-    - `effort_controller` (of type `JointGroupEffortController`, [configuration file](https://github.com/kroshu/kuka_drivers/tree/master/kuka_sunrise_fri_driver/config/effort_controller_config.yaml))
+    - `effort_controller` (of type `ForwardCommandController`, [configuration file](https://github.com/kroshu/kuka_drivers/tree/master/kuka_sunrise_fri_driver/config/effort_controller_config.yaml))
     - [`control_mode_handler`](https://github.com/kroshu/kuka_drivers/wiki/5_Controllers#31-kuka_control_mode_handler) (no configuration file)
     - `external_torque_broadcaster` (of type `JointStateBroadcaster`, [configuration file](https://github.com/kroshu/kuka_drivers/tree/master/kuka_sunrise_fri_driver/config/external_torque_broadcaster_config.yaml), publishes a `JointState` message type on the topic `external_torque_broadcaster/joint_states` containing the measured external torques for every joint)
 

--- a/kuka_driver_interfaces/CMakeLists.txt
+++ b/kuka_driver_interfaces/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(kuka_driver_interfaces)
 
 # Default to C99

--- a/kuka_drivers_core/CMakeLists.txt
+++ b/kuka_drivers_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(kuka_drivers_core)
 
 if(NOT CMAKE_C_STANDARD)
@@ -27,11 +27,19 @@ add_library(kuka_drivers_core SHARED
   src/parameter_handler.cpp
   src/controller_handler.cpp
 )
-ament_target_dependencies(kuka_drivers_core rclcpp rclcpp_lifecycle lifecycle_msgs)
+target_link_libraries(kuka_drivers_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  lifecycle_msgs::lifecycle_msgs
+)
 
 add_executable(control_node
   src/control_node.cpp)
-ament_target_dependencies(control_node rclcpp rclcpp_lifecycle controller_manager)
+target_link_libraries(control_node
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  controller_manager::controller_manager
+)
 
 ament_export_targets(export_kuka_drivers_core HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp rclcpp_lifecycle lifecycle_msgs)
@@ -40,7 +48,7 @@ ament_export_libraries(${PROJECT_NAME})
 add_library(communication_helpers SHARED
   include/communication_helpers/ros2_control_tools.hpp
   include/communication_helpers/service_tools.hpp)
-ament_target_dependencies(communication_helpers rclcpp)
+target_link_libraries(communication_helpers rclcpp::rclcpp)
 set_target_properties(communication_helpers PROPERTIES LINKER_LANGUAGE CXX)
 
 ament_export_targets(communication_helpers HAS_LIBRARY_TARGET)

--- a/kuka_iiqka_eac_driver/CMakeLists.txt
+++ b/kuka_iiqka_eac_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(kuka_iiqka_eac_driver)
 
 # Default to C99
@@ -34,14 +34,21 @@ add_library(${PROJECT_NAME} SHARED
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "KUKA_IIQKA_EAC_DRIVER_BUILDING_LIBRARY")
 
-ament_target_dependencies(${PROJECT_NAME} hardware_interface kuka_drivers_core kuka-external-control-sdk)
-target_link_libraries(${PROJECT_NAME} Kuka::kuka-external-control-sdk)
-
+target_link_libraries(${PROJECT_NAME}
+  hardware_interface::hardware_interface
+  kuka_drivers_core::kuka_drivers_core
+  Kuka::kuka-external-control-sdk
+)
 
 add_executable(robot_manager_node
   src/robot_manager_node.cpp)
-ament_target_dependencies(robot_manager_node std_msgs kuka_drivers_core controller_manager_msgs)
-target_link_libraries(robot_manager_node kuka_drivers_core::communication_helpers Kuka::kuka-external-control-sdk)
+target_link_libraries(robot_manager_node
+  std_msgs::std_msgs
+  kuka_drivers_core::kuka_drivers_core
+  controller_manager_msgs::controller_manager_msgs
+  kuka_drivers_core::communication_helpers
+  Kuka::kuka-external-control-sdk
+)
 
 pluginlib_export_plugin_description_file(hardware_interface hardware_interface.xml)
 

--- a/kuka_iiqka_eac_driver/config/effort_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/config/effort_controller_config.yaml
@@ -1,5 +1,6 @@
 /**/effort_controller:
   ros__parameters:
+    interface_name: effort
     joints:
     - joint_1
     - joint_2

--- a/kuka_iiqka_eac_driver/config/ros2_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/config/ros2_controller_config.yaml
@@ -13,7 +13,7 @@
     joint_group_impedance_controller:
       type: kuka_controllers/JointGroupImpedanceController
     effort_controller:
-      type: effort_controllers/JointGroupEffortController
+      type: forward_command_controller/ForwardCommandController
     control_mode_handler:
       type: kuka_controllers/ControlModeHandler
     event_broadcaster:

--- a/kuka_iiqka_eac_driver/launch/startup.launch.py
+++ b/kuka_iiqka_eac_driver/launch/startup.launch.py
@@ -173,19 +173,21 @@ def launch_setup(context, *args, **kwargs):
         prefix=prefix_cmd,
     )
 
+    controller_manager_name = "controller_manager"
+    if ns.perform(context) != "":
+        controller_manager_name = f"/{ns.perform(context)}/controller_manager"
+
     # Spawn controllers
     def controller_spawner(controller_name, prefix_cmd, param_file=None, activate=False):
         arg_list = [
             controller_name,
             "-c",
-            "controller_manager",
-            "-n",
-            ns,
+            controller_manager_name,
         ]
 
         # Add param-file if it's provided
         if param_file:
-            arg_list.extend(["--param-file", param_file])
+            arg_list.extend(["-p", param_file])
 
         if not activate:
             arg_list.append("--inactive")

--- a/kuka_iiqka_eac_driver/package.xml
+++ b/kuka_iiqka_eac_driver/package.xml
@@ -22,7 +22,7 @@
   <exec_depend>kuka_lbr_iisy_support</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
-  <exec_depend>effort_controllers</exec_depend>
+  <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>kuka_control_mode_handler</exec_depend>
   <exec_depend>kuka_event_broadcaster</exec_depend>

--- a/kuka_iiqka_eac_driver/test/config/test1_effort_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/test/config/test1_effort_controller_config.yaml
@@ -1,5 +1,6 @@
 test1/effort_controller:
   ros__parameters:
+    interface_name: position
     joints:
     - test1_joint_1
     - test1_joint_2
@@ -7,28 +8,3 @@ test1/effort_controller:
     - test1_joint_4
     - test1_joint_5
     - test1_joint_6
-    gains:
-      test1_joint_1:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test1_joint_2:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test1_joint_3:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test1_joint_4:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test1_joint_5:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test1_joint_6:
-        p: 5.0
-        i: 0.0
-        d: 0.1

--- a/kuka_iiqka_eac_driver/test/config/test1_effort_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/test/config/test1_effort_controller_config.yaml
@@ -1,6 +1,6 @@
 test1/effort_controller:
   ros__parameters:
-    interface_name: position
+    interface_name: effort
     joints:
     - test1_joint_1
     - test1_joint_2

--- a/kuka_iiqka_eac_driver/test/config/test1_ros2_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/test/config/test1_ros2_controller_config.yaml
@@ -17,7 +17,7 @@ test1/controller_manager:
 
 test1/effort_controller:
   ros__parameters:
-    interface_name: position
+    interface_name: effort
     joints:
     - test1_joint_1
     - test1_joint_2

--- a/kuka_iiqka_eac_driver/test/config/test1_ros2_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/test/config/test1_ros2_controller_config.yaml
@@ -9,8 +9,19 @@ test1/controller_manager:
     joint_group_impedance_controller:
       type: kuka_controllers/JointGroupImpedanceController
     effort_controller:
-      type: effort_controllers/JointGroupPositionController
+      type: forward_command_controller/ForwardCommandController
     control_mode_handler:
       type: kuka_controllers/ControlModeHandler
     event_broadcaster:
       type: kuka_controllers/EventBroadcaster
+
+test1/effort_controller:
+  ros__parameters:
+    interface_name: position
+    joints:
+    - test1_joint_1
+    - test1_joint_2
+    - test1_joint_3
+    - test1_joint_4
+    - test1_joint_5
+    - test1_joint_6

--- a/kuka_iiqka_eac_driver/test/config/test2_effort_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/test/config/test2_effort_controller_config.yaml
@@ -1,6 +1,6 @@
 test2/effort_controller:
   ros__parameters:
-    interface_name: position
+    interface_name: effort
     joints:
     - test2_joint_1
     - test2_joint_2

--- a/kuka_iiqka_eac_driver/test/config/test2_effort_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/test/config/test2_effort_controller_config.yaml
@@ -1,5 +1,6 @@
 test2/effort_controller:
   ros__parameters:
+    interface_name: position
     joints:
     - test2_joint_1
     - test2_joint_2
@@ -7,28 +8,3 @@ test2/effort_controller:
     - test2_joint_4
     - test2_joint_5
     - test2_joint_6
-    gains:
-      test2_joint_1:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test2_joint_2:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test2_joint_3:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test2_joint_4:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test2_joint_5:
-        p: 5.0
-        i: 0.0
-        d: 0.1
-      test2_joint_6:
-        p: 5.0
-        i: 0.0
-        d: 0.1

--- a/kuka_iiqka_eac_driver/test/config/test2_ros2_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/test/config/test2_ros2_controller_config.yaml
@@ -9,8 +9,19 @@ test2/controller_manager:
     joint_group_impedance_controller:
       type: kuka_controllers/JointGroupImpedanceController
     effort_controller:
-      type: effort_controllers/JointGroupPositionController
+      type: forward_command_controller/ForwardCommandController
     control_mode_handler:
       type: kuka_controllers/ControlModeHandler
     event_broadcaster:
       type: kuka_controllers/EventBroadcaster
+
+test2/effort_controller:
+  ros__parameters:
+    interface_name: position
+    joints:
+    - test2_joint_1
+    - test2_joint_2
+    - test2_joint_3
+    - test2_joint_4
+    - test2_joint_5
+    - test2_joint_6

--- a/kuka_iiqka_eac_driver/test/config/test2_ros2_controller_config.yaml
+++ b/kuka_iiqka_eac_driver/test/config/test2_ros2_controller_config.yaml
@@ -17,7 +17,7 @@ test2/controller_manager:
 
 test2/effort_controller:
   ros__parameters:
-    interface_name: position
+    interface_name: effort
     joints:
     - test2_joint_1
     - test2_joint_2

--- a/kuka_rsi_driver/CMakeLists.txt
+++ b/kuka_rsi_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(kuka_rsi_driver)
 
 # Default to C99
@@ -40,12 +40,18 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "KUKA_RSI_DRIVER_BUILDING_LIB
 # prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
-ament_target_dependencies(${PROJECT_NAME} hardware_interface kuka_drivers_core kuka-external-control-sdk)
-target_link_libraries(${PROJECT_NAME} Kuka::kuka-external-control-sdk)
+target_link_libraries(${PROJECT_NAME}
+  hardware_interface::hardware_interface
+  kuka_drivers_core::kuka_drivers_core
+  Kuka::kuka-external-control-sdk
+)
 
 # Shared library for robot_manager_base
 add_library(robot_manager_base STATIC src/robot_manager_base.cpp)
-ament_target_dependencies(robot_manager_base std_msgs kuka_drivers_core controller_manager_msgs)
+target_link_libraries(robot_manager_base
+  std_msgs::std_msgs
+  kuka_drivers_core::kuka_drivers_core
+  controller_manager_msgs::controller_manager_msgs)
 target_link_libraries(robot_manager_base kuka_drivers_core::communication_helpers)
 
 add_executable(robot_manager_node_extended src/robot_manager_node_extended.cpp)

--- a/kuka_rsi_driver/launch/startup.launch.py
+++ b/kuka_rsi_driver/launch/startup.launch.py
@@ -196,19 +196,21 @@ def launch_setup(context, *args, **kwargs):
         prefix=prefix_cmd,
     )
 
+    controller_manager_name = "controller_manager"
+    if ns.perform(context) != "":
+        controller_manager_name = f"/{ns.perform(context)}/controller_manager"
+
     # Spawn controllers
     def controller_spawner(controller_name, prefix_cmd, param_file=None, activate=False):
         arg_list = [
             controller_name,
             "-c",
-            "controller_manager",
-            "-n",
-            ns,
+            controller_manager_name,
         ]
 
         # Add param-file if it's provided
         if param_file:
-            arg_list.extend(["--param-file", param_file])
+            arg_list.extend(["-p", param_file])
 
         if not activate:
             arg_list.append("--inactive")

--- a/kuka_rsi_driver/package.xml
+++ b/kuka_rsi_driver/package.xml
@@ -22,6 +22,7 @@
   <depend>tinyxml_vendor</depend>
 
   <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>kuka_control_mode_handler</exec_depend>
   <exec_depend>kuka_kss_message_handler</exec_depend>

--- a/kuka_rsi_driver/test/config/test1_ros2_controller_config.yaml
+++ b/kuka_rsi_driver/test/config/test1_ros2_controller_config.yaml
@@ -9,6 +9,17 @@ test1/controller_manager:
     joint_group_impedance_controller:
       type: kuka_controllers/JointGroupImpedanceController
     effort_controller:
-      type: effort_controllers/JointGroupPositionController
+      type: forward_command_controller/ForwardCommandController
     control_mode_handler:
       type: kuka_controllers/ControlModeHandler
+
+test1/effort_controller:
+  ros__parameters:
+    interface_name: position
+    joints:
+    - test1_joint_1
+    - test1_joint_2
+    - test1_joint_3
+    - test1_joint_4
+    - test1_joint_5
+    - test1_joint_6

--- a/kuka_rsi_driver/test/config/test2_ros2_controller_config.yaml
+++ b/kuka_rsi_driver/test/config/test2_ros2_controller_config.yaml
@@ -9,6 +9,17 @@ test2/controller_manager:
     joint_group_impedance_controller:
       type: kuka_controllers/JointGroupImpedanceController
     effort_controller:
-      type: effort_controllers/JointGroupPositionController
+      type: forward_command_controller/ForwardCommandController
     control_mode_handler:
       type: kuka_controllers/ControlModeHandler
+
+test2/effort_controller:
+  ros__parameters:
+    interface_name: position
+    joints:
+    - test2_joint_1
+    - test2_joint_2
+    - test2_joint_3
+    - test2_joint_4
+    - test2_joint_5
+    - test2_joint_6

--- a/kuka_sunrise_fri_driver/CMakeLists.txt
+++ b/kuka_sunrise_fri_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(kuka_sunrise_fri_driver)
 
 # C11 needed for nanopb
@@ -82,13 +82,17 @@ add_library(${PROJECT_NAME} SHARED
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "KUKA_SUNRISE_FRI_DRIVER_BUILDING_LIBRARY")
 
-ament_target_dependencies(${PROJECT_NAME} kuka_driver_interfaces hardware_interface kuka_drivers_core)
+target_link_libraries(${PROJECT_NAME} kuka_driver_interfaces::kuka_driver_interfaces hardware_interface::hardware_interface kuka_drivers_core::kuka_drivers_core)
 target_link_libraries(${PROJECT_NAME} fri_client_sdk fri_connection)
 
 add_executable(robot_manager_node
   src/robot_manager_node.cpp)
-ament_target_dependencies(robot_manager_node kuka_driver_interfaces kuka_drivers_core std_msgs std_srvs
-  controller_manager_msgs)
+target_link_libraries(robot_manager_node
+  kuka_driver_interfaces::kuka_driver_interfaces
+  kuka_drivers_core::kuka_drivers_core
+  std_msgs::std_msgs
+  std_srvs::std_srvs
+  controller_manager_msgs::controller_manager_msgs)
 
 
 pluginlib_export_plugin_description_file(hardware_interface hardware_interface.xml)

--- a/kuka_sunrise_fri_driver/config/effort_controller_config.yaml
+++ b/kuka_sunrise_fri_driver/config/effort_controller_config.yaml
@@ -1,5 +1,6 @@
 /**/effort_controller:
   ros__parameters:
+    interface_name: effort
     joints:
     - joint_1
     - joint_2

--- a/kuka_sunrise_fri_driver/config/ros2_controller_config.yaml
+++ b/kuka_sunrise_fri_driver/config/ros2_controller_config.yaml
@@ -9,7 +9,7 @@
     joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
     effort_controller:
-      type: effort_controllers/JointGroupEffortController
+      type: forward_command_controller/ForwardCommandController
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     fri_state_broadcaster:

--- a/kuka_sunrise_fri_driver/launch/startup.launch.py
+++ b/kuka_sunrise_fri_driver/launch/startup.launch.py
@@ -171,19 +171,21 @@ def launch_setup(context, *args, **kwargs):
         prefix=prefix_cmd,
     )
 
+    controller_manager_name = "controller_manager"
+    if ns.perform(context) != "":
+        controller_manager_name = f"/{ns.perform(context)}/controller_manager"
+
     # Spawn controllers
     def controller_spawner(controller_name, prefix_cmd, param_file=None, activate=False):
         arg_list = [
             controller_name,
             "-c",
-            "controller_manager",
-            "-n",
-            ns,
+            controller_manager_name,
         ]
 
         # Add param-file if it's provided
         if param_file:
-            arg_list.extend(["--param-file", param_file])
+            arg_list.extend(["-p", param_file])
 
         if not activate:
             arg_list.append("--inactive")

--- a/kuka_sunrise_fri_driver/package.xml
+++ b/kuka_sunrise_fri_driver/package.xml
@@ -23,6 +23,7 @@
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>fri_configuration_controller</exec_depend>
   <exec_depend>fri_state_broadcaster</exec_depend>

--- a/kuka_sunrise_fri_driver/test/config/test1_ros2_controller_config.yaml
+++ b/kuka_sunrise_fri_driver/test/config/test1_ros2_controller_config.yaml
@@ -9,6 +9,17 @@ test1/controller_manager:
     joint_group_impedance_controller:
       type: kuka_controllers/JointGroupImpedanceController
     effort_controller:
-      type: effort_controllers/JointGroupPositionController
+      type: forward_command_controller/ForwardCommandController
     control_mode_handler:
       type: kuka_controllers/ControlModeHandler
+
+test1/effort_controller:
+  ros__parameters:
+    interface_name: position
+    joints:
+    - test1_joint_1
+    - test1_joint_2
+    - test1_joint_3
+    - test1_joint_4
+    - test1_joint_5
+    - test1_joint_6

--- a/kuka_sunrise_fri_driver/test/config/test2_ros2_controller_config.yaml
+++ b/kuka_sunrise_fri_driver/test/config/test2_ros2_controller_config.yaml
@@ -9,6 +9,17 @@ test2/controller_manager:
     joint_group_impedance_controller:
       type: kuka_controllers/JointGroupImpedanceController
     effort_controller:
-      type: effort_controllers/JointGroupPositionController
+      type: forward_command_controller/ForwardCommandController
     control_mode_handler:
       type: kuka_controllers/ControlModeHandler
+
+test2/effort_controller:
+  ros__parameters:
+    interface_name: position
+    joints:
+    - test2_joint_1
+    - test2_joint_2
+    - test2_joint_3
+    - test2_joint_4
+    - test2_joint_5
+    - test2_joint_6


### PR DESCRIPTION
Used: https://control.ros.org/lyrical/doc/ros2_controllers/doc/migration.html as reference

- replace deprecated JointGroup* controller plugins with forward_command_controller/ForwardCommandController
- add required interface_name parameters for migrated effort/position controllers in runtime and test controller configs
- switch package runtime deps from effort_controllers to forward_command_controller where needed
- update startup launch spawner arguments for current controller_manager CLI: remove unsupported -n usage, pass controller manager via fully qualified -c target, and use -p for controller param files
- update wiki docs to reflect ForwardCommandController usage
- raise cmake_minimum_required to 3.10 across kuka_drivers packages to remove deprecated CMake compatibility warnings

Partly done self and partly by GPT 5.3-codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved namespace-aware controller manager targeting during controller spawning.

* **Documentation**
  * Updated startup controller documentation and examples to use `ForwardCommandController`.

* **Chores**
  * Bumped the minimum CMake version and standardized build dependency linkage.
  * Migrated effort controller configuration (and related tests) to `ForwardCommandController`, added `interface_name`, and simplified parameters to joint lists; updated runtime dependencies accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->