### PR TITLE
Stabilize driver activation tests

### DIFF
--- a/kuka_drivers_core/CMakeLists.txt
+++ b/kuka_drivers_core/CMakeLists.txt
@@ -33,6 +33,11 @@ add_executable(control_node
   src/control_node.cpp)
 ament_target_dependencies(control_node rclcpp rclcpp_lifecycle controller_manager)
 
+add_executable(lifecycle_manager
+  src/lifecycle_manager.cpp)
+ament_target_dependencies(lifecycle_manager rclcpp lifecycle_msgs)
+target_link_libraries(lifecycle_manager communication_helpers)
+
 ament_export_targets(export_kuka_drivers_core HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp rclcpp_lifecycle lifecycle_msgs)
 ament_export_libraries(${PROJECT_NAME})
@@ -65,7 +70,7 @@ install(
   INCLUDES DESTINATION include
 )
 
-install(TARGETS ${PROJECT_NAME} control_node
+install(TARGETS ${PROJECT_NAME} control_node lifecycle_manager
   DESTINATION lib/${PROJECT_NAME})
 
 ament_export_include_directories(include)

--- a/kuka_drivers_core/src/lifecycle_manager.cpp
+++ b/kuka_drivers_core/src/lifecycle_manager.cpp
@@ -46,8 +46,8 @@ public:
     configure_delay_ = this->get_parameter("configure_delay").as_double();
     activate_delay_ = this->get_parameter("activate_delay").as_double();
 
-    change_state_client_ = this->create_client<lifecycle_msgs::srv::ChangeState>(
-      managed_node + "/change_state");
+    change_state_client_ =
+      this->create_client<lifecycle_msgs::srv::ChangeState>(managed_node + "/change_state");
 
     worker_thread_ = std::thread([this]() { this->run(); });
   }

--- a/kuka_drivers_core/src/lifecycle_manager.cpp
+++ b/kuka_drivers_core/src/lifecycle_manager.cpp
@@ -49,6 +49,8 @@ public:
     change_state_client_ =
       this->create_client<lifecycle_msgs::srv::ChangeState>(managed_node + "/change_state");
 
+    // Run delayed transitions in a worker thread so the executor can keep spinning
+    // and respond quickly to shutdown while timing logic runs independently.
     worker_thread_ = std::thread([this]() { this->run(); });
   }
 
@@ -61,6 +63,34 @@ public:
   }
 
 private:
+  bool sleepInterruptible(double delay_s, const char * phase)
+  {
+    if (delay_s <= 0.0)
+    {
+      return rclcpp::ok();
+    }
+
+    const auto delay = std::chrono::duration<double>(delay_s);
+    const auto start = std::chrono::steady_clock::now();
+
+    while (rclcpp::ok() && (std::chrono::steady_clock::now() - start) < delay)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    if (!rclcpp::ok())
+    {
+      const auto elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - start);
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Interrupted while waiting for %s: held %.3f s out of %.3f s",
+        phase, elapsed.count(), delay_s);
+      return false;
+    }
+
+    return true;
+  }
+
   bool changeState(uint8_t transition_id)
   {
     auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
@@ -88,7 +118,10 @@ private:
   void run()
   {
     // Wait for configure_delay seconds, then trigger configure
-    std::this_thread::sleep_for(std::chrono::duration<double>(configure_delay_));
+    if (!sleepInterruptible(configure_delay_, "configure delay"))
+    {
+      return;
+    }
 
     RCLCPP_INFO(this->get_logger(), "Sending 'configure' transition");
     if (!changeState(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
@@ -101,7 +134,10 @@ private:
     const double remaining_delay = activate_delay_ - configure_delay_;
     if (remaining_delay > 0.0)
     {
-      std::this_thread::sleep_for(std::chrono::duration<double>(remaining_delay));
+      if (!sleepInterruptible(remaining_delay, "activate delay"))
+      {
+        return;
+      }
     }
 
     RCLCPP_INFO(this->get_logger(), "Sending 'activate' transition");

--- a/kuka_drivers_core/src/lifecycle_manager.cpp
+++ b/kuka_drivers_core/src/lifecycle_manager.cpp
@@ -82,9 +82,8 @@ private:
     {
       const auto elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - start);
       RCLCPP_WARN(
-        this->get_logger(),
-        "Interrupted while waiting for %s: held %.3f s out of %.3f s",
-        phase, elapsed.count(), delay_s);
+        this->get_logger(), "Interrupted while waiting for %s: held %.3f s out of %.3f s", phase,
+        elapsed.count(), delay_s);
       return false;
     }
 

--- a/kuka_drivers_core/src/lifecycle_manager.cpp
+++ b/kuka_drivers_core/src/lifecycle_manager.cpp
@@ -1,0 +1,126 @@
+// Copyright 2026 KUKA Hungaria Kft.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include "communication_helpers/service_tools.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+/**
+ * @brief A node that drives a lifecycle node through configure and activate transitions.
+ *
+ * Uses the /<managed_node>/change_state service directly (with wait-for-service retry)
+ * to avoid the "Node not found" flakiness seen with CLI tools in CI environments.
+ *
+ * Parameters:
+ *   - managed_node   (string, default "robot_manager"): name of the target lifecycle node
+ *   - configure_delay (double, default 20.0):  seconds from startup to send configure
+ *   - activate_delay  (double, default 25.0):  seconds from startup to send activate
+ */
+class LifecycleManager : public rclcpp::Node
+{
+public:
+  explicit LifecycleManager(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+  : Node("lifecycle_manager", options)
+  {
+    this->declare_parameter<std::string>("managed_node", "robot_manager");
+    this->declare_parameter<double>("configure_delay", 20.0);
+    this->declare_parameter<double>("activate_delay", 25.0);
+
+    const auto managed_node = this->get_parameter("managed_node").as_string();
+    configure_delay_ = this->get_parameter("configure_delay").as_double();
+    activate_delay_ = this->get_parameter("activate_delay").as_double();
+
+    change_state_client_ = this->create_client<lifecycle_msgs::srv::ChangeState>(
+      managed_node + "/change_state");
+
+    worker_thread_ = std::thread([this]() { this->run(); });
+  }
+
+  ~LifecycleManager()
+  {
+    if (worker_thread_.joinable())
+    {
+      worker_thread_.join();
+    }
+  }
+
+private:
+  bool changeState(uint8_t transition_id)
+  {
+    auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
+    request->transition.id = transition_id;
+
+    auto response = kuka_drivers_core::sendRequest<lifecycle_msgs::srv::ChangeState::Response>(
+      change_state_client_, request, 1000, 5000);
+
+    if (!response)
+    {
+      RCLCPP_ERROR(this->get_logger(), "Change state service call failed");
+      return false;
+    }
+
+    if (!response->success)
+    {
+      RCLCPP_ERROR(
+        this->get_logger(), "Change state transition %u rejected by managed node", transition_id);
+      return false;
+    }
+
+    return true;
+  }
+
+  void run()
+  {
+    // Wait for configure_delay seconds, then trigger configure
+    std::this_thread::sleep_for(std::chrono::duration<double>(configure_delay_));
+
+    RCLCPP_INFO(this->get_logger(), "Sending 'configure' transition");
+    if (!changeState(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
+    {
+      RCLCPP_ERROR(this->get_logger(), "'configure' transition failed");
+      return;
+    }
+
+    // Wait for the remaining time before activate
+    const double remaining_delay = activate_delay_ - configure_delay_;
+    if (remaining_delay > 0.0)
+    {
+      std::this_thread::sleep_for(std::chrono::duration<double>(remaining_delay));
+    }
+
+    RCLCPP_INFO(this->get_logger(), "Sending 'activate' transition");
+    if (!changeState(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
+    {
+      RCLCPP_ERROR(this->get_logger(), "'activate' transition failed");
+    }
+  }
+
+  rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedPtr change_state_client_;
+  std::thread worker_thread_;
+  double configure_delay_{20.0};
+  double activate_delay_{25.0};
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<LifecycleManager>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/kuka_iiqka_eac_driver/package.xml
+++ b/kuka_iiqka_eac_driver/package.xml
@@ -28,7 +28,7 @@
   <exec_depend>kuka_event_broadcaster</exec_depend>
   <exec_depend>joint_group_impedance_controller</exec_depend>
 
-  <test_depend>ros2lifecycle</test_depend>
+  <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>

--- a/kuka_iiqka_eac_driver/test/test_driver_activation.py
+++ b/kuka_iiqka_eac_driver/test/test_driver_activation.py
@@ -15,7 +15,7 @@
 import unittest
 
 import launch
-import launch.actions
+import launch_ros.actions
 import launch_testing.actions
 import launch_testing.markers
 import pytest
@@ -45,22 +45,15 @@ def generate_test_description():
                     "mode": "mock",
                 }.items(),
             ),
-            launch.actions.TimerAction(
-                period=20.0,
-                actions=[
-                    launch.actions.ExecuteProcess(
-                        cmd=["ros2", "lifecycle", "set", "robot_manager", "configure"],
-                        output="screen",
-                    ),
-                ],
-            ),
-            launch.actions.TimerAction(
-                period=25.0,
-                actions=[
-                    launch.actions.ExecuteProcess(
-                        cmd=["ros2", "lifecycle", "set", "robot_manager", "activate"],
-                        output="screen",
-                    ),
+            launch_ros.actions.Node(
+                package="kuka_drivers_core",
+                executable="lifecycle_manager",
+                parameters=[
+                    {
+                        "managed_node": "robot_manager",
+                        "configure_delay": 20.0,
+                        "activate_delay": 25.0,
+                    }
                 ],
             ),
             launch_testing.actions.ReadyToTest(),

--- a/kuka_rsi_driver/package.xml
+++ b/kuka_rsi_driver/package.xml
@@ -29,7 +29,7 @@
   <exec_depend>controller_manager</exec_depend>
 
   <test_depend>kuka_rsi_simulator</test_depend>
-  <test_depend>ros2lifecycle</test_depend>
+  <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>

--- a/kuka_rsi_driver/test/test_driver_activation.py
+++ b/kuka_rsi_driver/test/test_driver_activation.py
@@ -15,7 +15,7 @@
 import unittest
 
 import launch
-import launch.actions
+import launch_ros.actions
 import launch_testing.actions
 import launch_testing.markers
 import pytest
@@ -53,22 +53,15 @@ def generate_test_description():
                     ]
                 )
             ),
-            launch.actions.TimerAction(
-                period=20.0,
-                actions=[
-                    launch.actions.ExecuteProcess(
-                        cmd=["ros2", "lifecycle", "set", "robot_manager", "configure"],
-                        output="screen",
-                    ),
-                ],
-            ),
-            launch.actions.TimerAction(
-                period=25.0,
-                actions=[
-                    launch.actions.ExecuteProcess(
-                        cmd=["ros2", "lifecycle", "set", "robot_manager", "activate"],
-                        output="screen",
-                    ),
+            launch_ros.actions.Node(
+                package="kuka_drivers_core",
+                executable="lifecycle_manager",
+                parameters=[
+                    {
+                        "managed_node": "robot_manager",
+                        "configure_delay": 20.0,
+                        "activate_delay": 25.0,
+                    }
                 ],
             ),
             launch_testing.actions.ReadyToTest(),

--- a/kuka_sunrise_fri_driver/package.xml
+++ b/kuka_sunrise_fri_driver/package.xml
@@ -31,7 +31,7 @@
   <exec_depend>joint_group_impedance_controller</exec_depend>
   <exec_depend>kuka_lbr_iiwa_support</exec_depend>
 
-  <test_depend>ros2lifecycle</test_depend>
+  <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>

--- a/kuka_sunrise_fri_driver/test/test_driver_activation.py
+++ b/kuka_sunrise_fri_driver/test/test_driver_activation.py
@@ -15,7 +15,7 @@
 import unittest
 
 import launch
-import launch.actions
+import launch_ros.actions
 import launch_testing.actions
 import launch_testing.markers
 import pytest
@@ -45,22 +45,15 @@ def generate_test_description():
                     "mode": "mock",
                 }.items(),
             ),
-            launch.actions.TimerAction(
-                period=20.0,
-                actions=[
-                    launch.actions.ExecuteProcess(
-                        cmd=["ros2", "lifecycle", "set", "robot_manager", "configure"],
-                        output="screen",
-                    ),
-                ],
-            ),
-            launch.actions.TimerAction(
-                period=25.0,
-                actions=[
-                    launch.actions.ExecuteProcess(
-                        cmd=["ros2", "lifecycle", "set", "robot_manager", "activate"],
-                        output="screen",
-                    ),
+            launch_ros.actions.Node(
+                package="kuka_drivers_core",
+                executable="lifecycle_manager",
+                parameters=[
+                    {
+                        "managed_node": "robot_manager",
+                        "configure_delay": 20.0,
+                        "activate_delay": 25.0,
+                    }
                 ],
             ),
             launch_testing.actions.ReadyToTest(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `lifecycle_manager` executable that drives a target ROS 2 node through configure and activate transitions using configurable startup delays.
  - Transition progress and failures are surfaced via logs.

- **Tests**
  - Updated driver activation tests to launch the new `lifecycle_manager` instead of invoking lifecycle commands/timers.
  - Switched test launch imports/dependencies to `launch_ros` (removing `ros2lifecycle`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->