### PR TITLE
Update CI triggers for push and pull requests

### DIFF
--- a/.github/workflows/industrial_ci_humble.yml
+++ b/.github/workflows/industrial_ci_humble.yml
@@ -17,6 +17,11 @@ on:
   pull_request:
     branches:
       - humble
+    paths-ignore:
+      - doc/**
+      - '**.md'
+      - LICENSE
+      - .github/workflows/deploy_wiki.yml
 
   schedule:
     # Run every Monday at 1PM UTC

--- a/.github/workflows/industrial_ci_humble.yml
+++ b/.github/workflows/industrial_ci_humble.yml
@@ -9,19 +9,10 @@ on:
   push:
     branches:
       - humble
-    paths-ignore:
-      - doc/**
-      - '**.md'
-      - LICENSE
-      - .github/workflows/deploy_wiki.yml
+
   pull_request:
     branches:
       - humble
-    paths-ignore:
-      - doc/**
-      - '**.md'
-      - LICENSE
-      - .github/workflows/deploy_wiki.yml
 
   schedule:
     # Run every Monday at 1PM UTC

--- a/.github/workflows/industrial_ci_jazzy.yml
+++ b/.github/workflows/industrial_ci_jazzy.yml
@@ -9,20 +9,10 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - doc/**
-      - '**.md'
-      - LICENSE
-      - .github/workflows/deploy_wiki.yml
-  # When there is a pull request against master
+
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - doc/**
-      - '**.md'
-      - LICENSE
-      - .github/workflows/deploy_wiki.yml
 
   schedule:
     # Run every Monday at 1PM UTC

--- a/.github/workflows/industrial_ci_jazzy.yml
+++ b/.github/workflows/industrial_ci_jazzy.yml
@@ -9,8 +9,6 @@ on:
   push:
     branches:
       - master
-      - feature/**
-      - fix/**
     paths-ignore:
       - doc/**
       - '**.md'
@@ -20,6 +18,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - doc/**
+      - '**.md'
+      - LICENSE
+      - .github/workflows/deploy_wiki.yml
 
   schedule:
     # Run every Monday at 1PM UTC


### PR DESCRIPTION
The CI ran twice during PRs for each commit. This should fix it, and less CI runs will happen in general.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI `push` triggers for the humble and jazzy branches to run more consistently without skipping changes limited to documentation/license and wiki deployment.
  * Adjusted the jazzy workflow’s branch matching to focus on `master` only.
  * Removed prior conditional path exclusions, so relevant CI checks won’t be bypassed based solely on doc or license edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->