### PR TITLE
Add cartesian motion state configuration checks

### DIFF
--- a/kuka_rsi_driver/scripts/generate_krc_rsi_config.py
+++ b/kuka_rsi_driver/scripts/generate_krc_rsi_config.py
@@ -246,16 +246,20 @@ def build_krc_xml(
 
     # Cartesian motion state
     cartesian_cfg = ms_cfg.get("cartesian", {}) or {}
-    cartesian_elem = cartesian_cfg.get("xml_element", _DEFAULT_CARTESIAN_ELEMENT)
-    if not isinstance(cartesian_elem, str) or not cartesian_elem:
-        raise ValueError("motion_state.cartesian.xml_element must be a non-empty string.")
-    cartesian_attrs = cartesian_cfg.get("xml_attributes", _DEFAULT_CARTESIAN_ATTRIBUTES)
-    if not isinstance(cartesian_attrs, list) or len(cartesian_attrs) != 6:
-        raise ValueError("motion_state.cartesian.xml_attributes must be a list with 6 entries.")
-    for attr in cartesian_attrs:
-        if not isinstance(attr, str) or not attr:
-            raise ValueError("motion_state.cartesian.xml_attributes contains invalid value.")
-    _emit_send_group(cartesian_elem, [f"{cartesian_elem}.{attr}" for attr in cartesian_attrs])
+    cartesian_enabled = cartesian_cfg.get("enabled", True)
+    if cartesian_cfg and cartesian_enabled:
+        cartesian_elem = cartesian_cfg.get("xml_element", _DEFAULT_CARTESIAN_ELEMENT)
+        if not isinstance(cartesian_elem, str) or not cartesian_elem:
+            raise ValueError("motion_state.cartesian.xml_element must be a non-empty string.")
+        cartesian_attrs = cartesian_cfg.get("xml_attributes", _DEFAULT_CARTESIAN_ATTRIBUTES)
+        if not isinstance(cartesian_attrs, list) or len(cartesian_attrs) != 6:
+            raise ValueError(
+                "motion_state.cartesian.xml_attributes must be a list with 6 entries."
+            )
+        for attr in cartesian_attrs:
+            if not isinstance(attr, str) or not attr:
+                raise ValueError("motion_state.cartesian.xml_attributes contains invalid value.")
+        _emit_send_group(cartesian_elem, [f"{cartesian_elem}.{attr}" for attr in cartesian_attrs])
 
     # Joint motion-state mappings. Contiguous runs that share an xml_element are
     # emitted together so default elements collapse into their DEF_ shortcut.

--- a/kuka_rsi_driver/scripts/generate_krc_rsi_config.py
+++ b/kuka_rsi_driver/scripts/generate_krc_rsi_config.py
@@ -247,6 +247,8 @@ def build_krc_xml(
     # Cartesian motion state
     cartesian_cfg = ms_cfg.get("cartesian", {}) or {}
     cartesian_enabled = cartesian_cfg.get("enabled", True)
+    if not isinstance(cartesian_enabled, bool):
+        raise ValueError("'motion_state.cartesian.enabled' must be boolean when provided.")
     if cartesian_cfg and cartesian_enabled:
         cartesian_elem = cartesian_cfg.get("xml_element", _DEFAULT_CARTESIAN_ELEMENT)
         if not isinstance(cartesian_elem, str) or not cartesian_elem:


### PR DESCRIPTION
Add check if cartesian states are available or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cartesian motion-state SEND configuration is now generated only when explicitly enabled and a Cartesian configuration is provided.
  * Prevented unintended default Cartesian XML elements/attributes from being added when no Cartesian configuration is present.
  * Kept existing validation for custom XML elements and attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->