### PR TITLE
Align docs to pkg name change in examples, fix conflicting default value for kl_support_package

### DIFF
--- a/doc/wiki/1_iiQKA_EAC.md
+++ b/doc/wiki/1_iiQKA_EAC.md
@@ -79,7 +79,7 @@ After successful startup, the `robot_manager` node has to be activated to start 
   ros2 lifecycle set robot_manager activate
   ```
 
-On successful activation the brakes of the robot will be released and external control is started using the requested control mode. To test moving the robot, the `rqt_joint_trajectory_controller` is not recommended, use the launch file in the `iiqka_moveit_example` package instead (usage is described in the [Additional packages](https://github.com/kroshu/kuka_drivers/wiki#moveit-integration) section of the project overview).
+On successful activation the brakes of the robot will be released and external control is started using the requested control mode. To test moving the robot, the `rqt_joint_trajectory_controller` is not recommended, use the launch file in the `moveit_example` package instead (usage is described in the [Additional packages](https://github.com/kroshu/kuka_drivers/wiki#moveit-integration) section of the project overview).
 
 It is important to note, that the commanded and measures torques have a different meaning: the `effort` command interface accepts values that should be superimposed on internal gravity compensation, while the state interface provides the actually measured torques (sum on internal and external effects).
 

--- a/doc/wiki/2_RSI.md
+++ b/doc/wiki/2_RSI.md
@@ -263,7 +263,7 @@ Upload the generated file to the controller as described in [Update and upload c
   - `eki_rsi` or `mxa_rsi`: RSI program is automatically selected and started
 
 
-On successful activation the brakes of the robot will be released and external control is started. To test moving the robot, the `rqt_joint_trajectory_controller` is not recommended, use the launch file in the `iiqka_moveit_example` package instead (found in examples repo, usage is described in the [Additional packages](https://github.com/kroshu/kuka_drivers/wiki#moveit-integration) section of the project overview).
+On successful activation the brakes of the robot will be released and external control is started. To test moving the robot, the `rqt_joint_trajectory_controller` is not recommended, use the launch file in the `moveit_example` package instead (found in examples repo, usage is described in the [Additional packages](https://github.com/kroshu/kuka_drivers/wiki#moveit-integration) section of the project overview).
 
 ### Launch arguments
 

--- a/doc/wiki/3_Sunrise_FRI.md
+++ b/doc/wiki/3_Sunrise_FRI.md
@@ -66,7 +66,7 @@ The parameters in the driver configuration file can be also changed during runti
     ros2 lifecycle set robot_manager activate
     ```
 
-On successful activation the brakes of the robot will be released and external control is started using the requested control mode. To test moving the robot, the `rqt_joint_trajectory_controller` is not recommended, use the launch file in the `iiqka_moveit_example` package instead (usage is described in the [Additional packages](https://github.com/kroshu/kuka_drivers/wiki#moveit-integration) section of the project overview).
+On successful activation the brakes of the robot will be released and external control is started using the requested control mode. To test moving the robot, the `rqt_joint_trajectory_controller` is not recommended, use the launch file in the `moveit_example` package instead (usage is described in the [Additional packages](https://github.com/kroshu/kuka_drivers/wiki#moveit-integration) section of the project overview).
 
 #### Launch arguments
 

--- a/doc/wiki/Home.md
+++ b/doc/wiki/Home.md
@@ -106,9 +106,9 @@ The repository contains a few other packages aside from the 3 drivers:
 
 ## MoveIt integration
 
-The `ros2_control` framework supports MoveIt out-of-the-box, as the `joint_trajectory_controller` can interpolate the trajectories planned by it. Setting up Moveit is a little more complex, therefore an example package, `iiqka_moveit_example`, is provided to help developers. The `iiqka_moveit_example` package is located in the [`examples`](https://github.com/kroshu/examples) repository. This contains basic examples of using MoveIt with the driver. Additionally, it contains a [launch file](https://github.com/kroshu/examples/blob/master/iiqka_moveit_example/launch/launch_trajectory_publisher.launch.py) that commands 4 goal positions near the home position cyclically (the points and parameters can be modified in [this](https://github.com/kroshu/examples/blob/master/iiqka_moveit_example/config/dummy_publisher.yaml) configuration file). This can be used to test moving any robot with the driver, and is the recommended way instead of the `rqt_joint_trajectory_controller`, which commands very jerky trajectories due to batching.
+The `ros2_control` framework supports MoveIt out-of-the-box, as the `joint_trajectory_controller` can interpolate the trajectories planned by it. Setting up Moveit is a little more complex, therefore an example package, `moveit_example`, is provided to help developers. The `moveit_example` package is located in the [`examples`](https://github.com/kroshu/examples) repository. This contains basic examples of using MoveIt with the driver. Additionally, it contains a [launch file](https://github.com/kroshu/examples/blob/master/moveit_example/launch/launch_trajectory_publisher.launch.py) that commands 4 goal positions near the home position cyclically (the points and parameters can be modified in [this](https://github.com/kroshu/examples/blob/master/moveit_example/config/dummy_publisher.yaml) configuration file). This can be used to test moving any robot with the driver, and is the recommended way instead of the `rqt_joint_trajectory_controller`, which commands very jerky trajectories due to batching.
 
-As mentioned earlier, the package contains a [launch file](https://github.com/kroshu/examples/blob/master/iiqka_moveit_example/launch/moveit_planning_example.launch.py) that starts the iiQKA driver, `rviz`, and the `move_group` server with the required configuration. The `robot_manager` lifecycle node should be configured and activated after startup.
+As mentioned earlier, the package contains a [launch file](https://github.com/kroshu/examples/blob/master/moveit_example/launch/moveit_planning_example.launch.py) that starts the iiQKA driver, `rviz`, and the `move_group` server with the required configuration. The `robot_manager` lifecycle node should be configured and activated after startup.
 
 After activation, the Motion Planning plugin can be added (`Add` -> `moveit_ros_visualisation` -> `MotionPlanning`) to plan trajectories from the `rviz` GUI. (`Planning group` in the `Planning` tab should be changed to `manipulator`.)
 
@@ -141,7 +141,7 @@ The joint position values commanded are available on the topic `/joint_group_imp
 
 Additionally the `trajectory_execution.allowed_start_tolerfance` parameter in `moveit_controllers.yaml` (found in the moveit support packages) should be increased based on the actual displacement between commanded and measured joint values.
 
-If you would like to only move the robot by sending a goal to the `joint_trajectory_controller` for interpolation (e.g. with the [example trajectory publisher](https://github.com/kroshu/examples/blob/master/iiqka_moveit_example/launch/launch_trajectory_publisher.launch.py)), the following line should be added to the controller configuration file:
+If you would like to only move the robot by sending a goal to the `joint_trajectory_controller` for interpolation (e.g. with the [example trajectory publisher](https://github.com/kroshu/examples/blob/master/moveit_example/launch/launch_trajectory_publisher.launch.py)), the following line should be added to the controller configuration file:
 
 ```yaml
 open_loop_control: true

--- a/kuka_rsi_driver/launch/startup.launch.py
+++ b/kuka_rsi_driver/launch/startup.launch.py
@@ -111,7 +111,6 @@ def launch_setup(context, *args, **kwargs):
     template_xacro_args = []
 
     if use_external_axis_value:
-        kl_support_package = kl_support_package_value or "kuka_kl_support"
         robot_ros2_control_macro_file = _ros2_control_macro_file_from_family(robot_family_value)
 
         robot_model_macro_path = os.path.join(
@@ -136,7 +135,7 @@ def launch_setup(context, *args, **kwargs):
             )
 
         kl_model_macro_path = os.path.join(
-            get_package_share_directory(kl_support_package),
+            get_package_share_directory(kl_support_package_value),
             "urdf",
             kl_model_value + "_macro.xacro",
         )
@@ -147,7 +146,7 @@ def launch_setup(context, *args, **kwargs):
             )
 
         kl_ros2_control_macro_path = os.path.join(
-            get_package_share_directory(kl_support_package),
+            get_package_share_directory(kl_support_package_value),
             "urdf",
             kl_ros2_control_macro_file_value,
         )
@@ -171,7 +170,7 @@ def launch_setup(context, *args, **kwargs):
             robot_family_value,
             " ",
             "kl_support_package:=",
-            kl_support_package,
+            kl_support_package_value,
             " ",
             "robot_ros2_control_macro_file:=",
             robot_ros2_control_macro_file,
@@ -403,10 +402,10 @@ def generate_launch_description():
     launch_arguments.append(
         DeclareLaunchArgument(
             "kl_support_package",
-            default_value="",
+            default_value="kuka_kl_support",
             description=(
                 "Package containing KL model and KL ros2_control xacro macros. "
-                "If empty, falls back to kuka_kl_support."
+                "Defaults to kuka_kl_support."
             ),
         )
     )


### PR DESCRIPTION
Align docs to pkg name change in examples, fix conflicting default value for kl_support_package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated driver startup instructions to use the generalized `moveit_example` package and current example links.
  * Updated controller configuration guidance to reference the generalized trajectory publisher launch file.

* **Bug Fixes**
  * Improved external-axis launch configuration by providing a consistent default support package and using the configured value directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->