### PR TITLE
`rsi_xml_config_file` missing from base parameters

### DIFF
--- a/kuka_rsi_driver/launch/startup.launch.py
+++ b/kuka_rsi_driver/launch/startup.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2023 KUKA Hungaria Kft.
+# Copyright 2026 KUKA Hungaria Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kuka_rsi_driver/launch/startup.launch.py
+++ b/kuka_rsi_driver/launch/startup.launch.py
@@ -184,9 +184,6 @@ def launch_setup(context, *args, **kwargs):
             " ",
             "kl_ros2_control_joints_macro:=",
             kl_ros2_control_joints_macro_value,
-            " ",
-            "rsi_xml_config_file:=",
-            rsi_xml_config_file,
         ]
         effective_robot_model = f"{robot_model_value}_with_{kl_model_value}"
 
@@ -249,7 +246,11 @@ def launch_setup(context, *args, **kwargs):
         " ",
         "verify_robot_model:=",
         verify_robot_model,
+        " ",
+        "rsi_xml_config_file:=",
+        rsi_xml_config_file,
     ]
+
     if use_external_axis_value:
         xacro_arguments.extend(
             [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RSI XML configuration is now applied consistently, including setups without an external axis.
* **Chores**
  * Updated the copyright year to 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->